### PR TITLE
Add redix and xandra to app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ build:
 	mix do deps.get + compile
 
 run:
+	iex -S mix phx.server
+
+run-server-only:
 	mix phx.server
 
 lint:

--- a/lib/cars_app/application.ex
+++ b/lib/cars_app/application.ex
@@ -11,6 +11,8 @@ defmodule CarsApp.Application do
       CarsAppWeb.Telemetry,
       {DNSCluster, query: Application.get_env(:cars_app, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: CarsApp.PubSub},
+      {Redix, host: "127.0.0.1", port: 6379, name: :redix},
+      {Xandra, nodes: ["127.0.0.1:9042"], name: :xandra},
       # Start a worker by calling: CarsApp.Worker.start_link(arg)
       # {CarsApp.Worker, arg},
       # Start to serve requests, typically the last entry


### PR DESCRIPTION
With this change now we can use Redix and Xandra on the app.

This can be tested using
```
make up
```
to run redis and cassandra on docker and in another terminal
```
make run
```

Then you can test it on the elixir VM, you can use command like

``` elixir
Redix.command(:redix, ["set", "value", 10]
Xandra.execute(:xandra, "CREATE KEYSPACE test WITH REPLICATION = {'class': 'SimpleStrategy'}")
```