### PR TITLE
Fix for makefile to run docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 .PHONY: up setup build run lint fmt test test.watch
 
 up:
-	docker-compose up
+	docker-compose up -d
+
+down:
+	docker-compose down
+
 setup:
 	make build
 


### PR DESCRIPTION
What the title says

Basically now we can run `make up` to run the docker-compose without problems, and also added `make down` to run `docker-compose down`